### PR TITLE
Add cache for var attribute lookup

### DIFF
--- a/lib/core_ext/deep_fetch.rb
+++ b/lib/core_ext/deep_fetch.rb
@@ -1,8 +1,41 @@
 require 'backport_dig' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+require 'singleton'
+
+class VarCache
+
+  include Singleton
+
+  def self.fetch_or_store(key)
+    instance.fetch_or_store(key)
+  end
+
+  def initialize
+    @storage = {}
+  end
+
+  def fetch(key)
+    @storage[key]
+  end
+
+  def store(key)
+    @storage[key] = attributes(key)
+  end
+
+  def fetch_or_store(key)
+    fetch(key) || store(key)
+  end
+
+  private
+
+    def attributes(key)
+      key.to_s.split('.')
+    end
+
+end
 
 class Hash
   def deep_fetch(key, default = nil)
-    keys = key.to_s.split('.')
+    keys = VarCache.fetch_or_store(key)
     value = dig(*keys) rescue default
     value.nil? ? default : value  # value can be false (Boolean)
   end
@@ -10,7 +43,7 @@ end
 
 class Array
   def deep_fetch(index, default = nil)
-    indexes = index.to_s.split('.').map(&:to_i)
+    indexes = VarCache.fetch_or_store(index).map(&:to_i)
     value = dig(*indexes) rescue default
     value.nil? ? default : value  # value can be false (Boolean)
   end


### PR DESCRIPTION
# Description

When variable lookup need to be executed, the old implementation split the key string into a new an array every time. In those scenarios, when the same variable need to be looked up several times, this causes a lot of unneccessary object allocations.

# Implementation

Added a cache singleton class to store the split key attrubutes.