### PR TITLE
Drop support of symbol hash keys

### DIFF
--- a/lib/core_ext/deep_fetch.rb
+++ b/lib/core_ext/deep_fetch.rb
@@ -43,11 +43,7 @@ end
 class Hash
   def deep_fetch(key, default = nil)
     keys = VarCache.fetch_or_store(key)
-    value = keys.inject(self) do |memo, item|
-      memo.key?(item) ? memo[item] : memo[item.to_sym]
-    rescue
-      default
-    end
+    value = dig(*keys) rescue default
     value.nil? ? default : value  # value can be false (Boolean)
   end
 end

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -133,11 +133,11 @@ class JSONLogicTest < Minitest::Test
     )
 
     provided_data_missing_y = {
-      x: 3,
+      'x' => 3,
     }
 
     provided_data_missing_x = {
-      y: 4,
+      'y' => 4,
     }
 
     assert_equal ["y"], JSONLogic.apply({"missing": [vars]}, provided_data_missing_y)


### PR DESCRIPTION
# Summary

Handling dynamic conversion between `String` and `Symbol` keys creates a significant perfomance bottleneck. With this change, if data is passed as `Hash`, keys need to be provided as `String`. As a result, we can expect **~30% performance improvement**.

# Test Suite

```
require 'benchmark/ips'
require "bundler/gem_tasks"
require 'json_logic'


data = { 'a' => 1, 'b' => { 'c' => 2, 'd' => 3 } }
logic = { 'var' => 'b.c' }

compiled = JSONLogic.compile(logic)

Benchmark.ips do |x|
  x.report("apply-compiled-logic") { compiled.evaluate(data) }
  x.compare!
end
```

## Before PR
```
Warming up --------------------------------------
apply-compiled-logic    59.924k i/100ms
Calculating -------------------------------------
apply-compiled-logic    603.481k (± 1.4%) i/s -      3.056M in   5.065220s
```

## After PR
```
Warming up --------------------------------------
apply-compiled-logic    79.318k i/100ms
Calculating -------------------------------------
apply-compiled-logic    799.975k (± 2.5%) i/s -      4.045M in   5.059387s
```