### PR TITLE
Rewrite `and` operator with `#index`

### DIFF
--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -93,8 +93,8 @@ module JSONLogic
       '!!'    => ->(v, d) { v[0].truthy? },
       'or'    => ->(v, d) { v.find(&:truthy?) || v.last },
       'and'   => ->(v, d) {
-        result = v.find(&:falsy?)
-        result.nil? ? v.last : result
+        idx = v.index(&:falsy?)
+        idx.nil? ? v.last : v[idx]
       },
       '?:'    => ->(v, d) { LAMBDAS['if'].call(v, d) },
       '>'     => ->(v, d) { v.map(&:to_f).each_cons(2).all? { |i, j| i > j } },


### PR DESCRIPTION
# Description

`#index` uses less allocations and has better performance than `#find`

# Performance Benchmark

## Test Suit
```
require 'benchmark/ips'
require "bundler/gem_tasks"
require 'json_logic'

logic = {
  "and" => [true, 1, 'a']
}


compiled = JSONLogic.compile(logic)

Benchmark.ips do |x|
  x.report("and_operator") { compiled.evaluate(nil) }

  x.compare!
end
```

## Before PR

```
Warming up --------------------------------------
        and_operator   131.476k i/100ms
Calculating -------------------------------------
        and_operator      1.319M (± 0.5%) i/s -      6.705M in   5.085356s
```

## After PR
```
Warming up --------------------------------------
        and_operator   145.108k i/100ms
Calculating -------------------------------------
        and_operator      1.471M (± 0.7%) i/s -      7.401M in   5.031494s
```

**About 11% improvement**