### PR TITLE
Rewrite `if` operator with while loop

### DIFF
--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -78,9 +78,13 @@ module JSONLogic
         v[1]
       end,
       'if' => ->(v, d) {
-        v.each_slice(2) do |condition, value|
+        i = 0
+        while i < v.length do
+          condition = v[i]
+          value = v[i+1]
           return condition if value.nil?
           return value if condition.truthy?
+          i += 2
         end
 
         nil


### PR DESCRIPTION
# Description

`#each_slice` would cause additional object allocations. Using basic `while loop` would have better performance.

# Performance Benchmark
## Test Suit
```
require 'benchmark/ips'
require "bundler/gem_tasks"
require 'json_logic'

true_case = {
  "if" => [true, 1, 'a']
}

false_case = {
  "if" => [false, 1, 'a']
}


true_case_compiled = JSONLogic.compile(true_case)
false_case_compiled = JSONLogic.compile(false_case)

Benchmark.ips do |x|
  x.report("if_operator[true]") { true_case_compiled.evaluate(nil) }
  x.report("if_operator[false]") { false_case_compiled.evaluate(nil) }
end
```

## Before PR
```
Warming up --------------------------------------
   if_operator[true]   120.624k i/100ms
  if_operator[false]   113.248k i/100ms
Calculating -------------------------------------
   if_operator[true]      1.183M (± 2.2%) i/s -      6.031M in   5.101916s
  if_operator[false]      1.159M (± 2.1%) i/s -      5.889M in   5.082047s
```


## After PR
```
Warming up --------------------------------------
   if_operator[true]   164.110k i/100ms
  if_operator[false]   154.327k i/100ms
Calculating -------------------------------------
   if_operator[true]      1.642M (± 0.3%) i/s -      8.370M in   5.097412s
  if_operator[false]      1.533M (± 1.0%) i/s -      7.716M in   5.033156s
```

**About 32% ~ 35% improvement**